### PR TITLE
Fix deprecation warning in Swift 4

### DIFF
--- a/Source/TPObfuscatedStringConverter.swift
+++ b/Source/TPObfuscatedStringConverter.swift
@@ -11,13 +11,12 @@ import Foundation
 class TPObfuscatedStringConverter {
     
     class func convert(phrase: String) -> String {
-        let characters = phrase.characters
         var result = [String]()
         
         let formatter = NumberFormatter()
         formatter.numberStyle = NumberFormatter.Style.spellOut
         
-        for c in characters {
+        for c in phrase {
             let s = String(c).unicodeScalars
             let unicode = Int(s[s.startIndex].value)
             switch unicode {


### PR DESCRIPTION
-  `characters` function has been deprecated in Swift 3.2. Iterating through the characters within a String object can now be done via a for-loop.